### PR TITLE
feature/additional algorithms support

### DIFF
--- a/tcp_congestion/src/App.js
+++ b/tcp_congestion/src/App.js
@@ -4,6 +4,7 @@ import NetworkDashboard from './NetworkDashboard';
 import Logger from './Logger';
 import Simulation from './simulation';
 import SimulationReport from './SimulationReport';
+import FastCongestionControl from './FastCongestionControl';
 
 function App() {
   const [nodes, setNodes] = useState([]);
@@ -29,6 +30,9 @@ function App() {
   const [lossPercentage, setLossPercentage] = useState(0);
   const [packetsSent, setPacketsSent] = useState(0); // New state to track packets sent
   const [packetsLost, setPacketsLost] = useState(0); // New state to track packets lost
+
+  // New state to keep track of the algorithm selected
+  const [algorithm, setAlgorithm] = useState('default');
 
   const updateNetworkMetrics = useCallback(() => {
     if (!simulation) return;
@@ -252,6 +256,10 @@ function App() {
     logger.exportLogs(format);
   };
 
+  const handleUpdateNetwork = () => {
+    updateNetworkMetrics(); // A function that recalculates and updates network statistics
+  };
+
   return (
     <div className="App">
       <header className="App-header">
@@ -365,6 +373,25 @@ function App() {
                 />
                 <button onClick={() => simulatePacketLoss(lossPercentage)}>Simulate Loss</button>
               </div>
+            )}
+
+            {/* Algorithm selection dropdown */}
+            <div className="section">
+              <label>Select Congestion Control Algorithm:</label>
+              <select onChange={(e) => setAlgorithm(e.target.value)} value={algorithm}>
+                <option value="default">Default</option>
+                <option value="fast_congestion_control">Fast Congestion Control (Retransmit + Recovery)</option>
+              </select>
+            </div>
+
+            {/* Render the selected algorithm */}
+            {algorithm === 'fast_congestion_control' && (
+              <FastCongestionControl
+                nodes={nodes}
+                setNodes={setNodes}
+                selectedNodeId={selectedNodeId}
+                onUpdateNetwork={handleUpdateNetwork}
+              />
             )}
 
             <div className="section send">

--- a/tcp_congestion/src/FastCongestionControl.js
+++ b/tcp_congestion/src/FastCongestionControl.js
@@ -1,0 +1,77 @@
+import React, { useState, useEffect, useCallback } from 'react';
+
+const FastCongestionControl = ({ nodes, setNodes, selectedNodeId, onUpdateNetwork }) => {
+  const [duplicateAcks, setDuplicateAcks] = useState(0);
+  const [recoveryMode, setRecoveryMode] = useState(false);
+  const DUPLICATE_ACK_THRESHOLD = 3; // Threshold for fast retransmit
+
+  // Cache the current node for efficiency
+  const currentNode = nodes[selectedNodeId];
+
+  const handleFastRetransmit = useCallback(() => {
+    if (currentNode && !recoveryMode) {
+      console.log('Fast Retransmit triggered');
+      const updatedNode = { ...currentNode, cwnd: 1 }; // Reset congestion window after retransmit
+      setNodes(prevNodes => {
+        const newNodes = [...prevNodes];
+        newNodes[selectedNodeId] = updatedNode;
+        return newNodes; // Update node data
+      });
+      setRecoveryMode(true); // Enter recovery mode
+      setDuplicateAcks(0); // Reset duplicate ACK counter
+      onUpdateNetwork(); // Update the network metrics after retransmit
+    }
+  }, [currentNode, recoveryMode, setNodes, selectedNodeId, onUpdateNetwork]);
+
+  const handleFastRecovery = useCallback(() => {
+    if (currentNode && recoveryMode) {
+      console.log('Fast Recovery mode');
+      const newCwnd = Math.max(currentNode.cwnd / 2, 1); // Reduce congestion window by half
+      const updatedNode = { ...currentNode, cwnd: newCwnd };
+      setNodes(prevNodes => {
+        const newNodes = [...prevNodes];
+        newNodes[selectedNodeId] = updatedNode;
+        return newNodes; // Update node data
+      });
+      setRecoveryMode(false); // Exit recovery mode
+      onUpdateNetwork(); // Update network metrics after recovery
+    }
+  }, [currentNode, recoveryMode, setNodes, selectedNodeId, onUpdateNetwork]);
+
+  useEffect(() => {
+    if (!currentNode) return;
+
+    // Detect if duplicate ACK received
+    const lastSentPacket = currentNode.sent[currentNode.sent.length - 1];
+    if (currentNode.ack === lastSentPacket) {
+      setDuplicateAcks(prevAcks => {
+        // Only increment if not in recovery mode
+        return recoveryMode ? prevAcks : Math.min(prevAcks + 1, DUPLICATE_ACK_THRESHOLD + 1); // cap to avoid excess
+      });
+    } else {
+      // If ACK does not match the last sent packet, reset duplicate ACKs
+      setDuplicateAcks(0);
+    }
+  }, [currentNode, recoveryMode]);
+
+  useEffect(() => {
+    if (duplicateAcks >= DUPLICATE_ACK_THRESHOLD && !recoveryMode) {
+      handleFastRetransmit();
+    }
+
+    if (recoveryMode) {
+      handleFastRecovery();
+    }
+
+  }, [duplicateAcks, recoveryMode, handleFastRetransmit, handleFastRecovery]);
+
+  return (
+    <div>
+      <h4>Fast Congestion Control (Fast Retransmit + Fast Recovery)</h4>
+      <p>Duplicate ACKs: {duplicateAcks}</p>
+      <p>Recovery Mode: {recoveryMode ? 'Active' : 'Inactive'}</p>
+    </div>
+  );
+};
+
+export default FastCongestionControl;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

I have implemented the Fast Retransmit and Fast Recovery Algorithms in the simulator. The Fast Retransmit Algorithm will get triggered when 3 duplicate acks are received and after retransmit, Fast Recovery algorithm will get triggered.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #4 Implementation of support for additional congestion control algorithms in the simulator.

## Type of change

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
Supporting a wider range of congestion control algorithms will make the simulator more comprehensive, allowing users to study and compare the behavior of different algorithms under various network conditions.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have registered myself at [Contrihub website](https://sac.mnnit.ac.in/contrihub).
- [x] My code follows the code style of this project.
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
